### PR TITLE
fix: QA사항 수정

### DIFF
--- a/packages/react-native/src/components/common/DateSelect.tsx
+++ b/packages/react-native/src/components/common/DateSelect.tsx
@@ -3,24 +3,17 @@ import { useEffect, useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { Calendar } from 'react-native-calendars';
 import BottomSheet from './BottomSheet';
-import useCalendar from '@/hooks/useCalendar';
+import useCalendar, { DateRange } from '@/hooks/useCalendar';
 import { CALENDAR_THEME } from '@/constants/CALENDAR_THEME';
 import BackIcon from '@/assets/BackIcon';
 
 export interface DateSelectProps {
-  date: {
-    start: Date;
-    end: Date;
-  };
-  setDate: React.Dispatch<
-    React.SetStateAction<{
-      start: Date;
-      end: Date;
-    }>
-  >;
+  date: DateRange;
+  setDate: React.Dispatch<React.SetStateAction<DateRange>>;
 }
 
-const getDisplayDate = (displayDate: Date) => {
+const getDisplayDate = (displayDate?: Date) => {
+  if (!displayDate) return '선택해주세요';
   return displayDate.toISOString().split('T')[0];
 };
 

--- a/packages/react-native/src/components/maps/RecordPostForm.tsx
+++ b/packages/react-native/src/components/maps/RecordPostForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Asset } from 'react-native-image-picker';
-import { View } from 'react-native';
+import { Alert, View } from 'react-native';
 import { Button, Font } from 'design-system';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import RecordFormTitle from './RecordFormTitle';
@@ -58,6 +58,16 @@ export default function RecordPostForm() {
 
   const handlePress = async () => {
     if (!validate() || !imageAssets) {
+      return;
+    }
+
+    if (!date.start) {
+      Alert.alert('시작 날짜를 선택해주세요.');
+      return;
+    }
+
+    if (!date.end) {
+      Alert.alert('끝 날짜를 선택해주세요.');
       return;
     }
 

--- a/packages/react-native/src/components/tripPlan/TripPlannerBottomSheetCalendar.tsx
+++ b/packages/react-native/src/components/tripPlan/TripPlannerBottomSheetCalendar.tsx
@@ -1,4 +1,4 @@
-import { View } from 'react-native';
+import { Alert, View } from 'react-native';
 import { Button, Font } from 'design-system';
 import { Calendar } from 'react-native-calendars';
 import BackIcon from '@/assets/BackIcon';
@@ -25,6 +25,16 @@ export default function TripPlannerBottomSheetCalendar({
   const { mutateAsync, isPending } = useSchedulePeriodMutation();
 
   const changePeriod = async () => {
+    if (!date.start) {
+      Alert.alert('시작 날짜를 선택해주세요.');
+      return;
+    }
+
+    if (!date.end) {
+      Alert.alert('종료 날짜를 선택해주세요.');
+      return;
+    }
+
     await mutateAsync({
       id: selectedPlan.id,
       startDate: date.start.toISOString().replace('.000Z', ''),

--- a/packages/react-native/src/hooks/useProfileImage.tsx
+++ b/packages/react-native/src/hooks/useProfileImage.tsx
@@ -43,7 +43,7 @@ export default function useProfileImage() {
               color: profile.colorSet.color,
             }}
           >
-            {profile.nickname}
+            {profile.nickname.slice(0, 3)}
           </Text>
         </View>
       );

--- a/packages/react-native/src/hooks/useRecordFormState.tsx
+++ b/packages/react-native/src/hooks/useRecordFormState.tsx
@@ -3,6 +3,7 @@ import { RecordGetResponse } from '@/apis/queries/records/useRecordDetailQuery';
 import { CitySelectValue } from '@/components/common/CitySelect';
 import { DateSelectProps } from '@/components/common/DateSelect';
 import { getDisplayRegion } from '@/utils/getDisplayRegionName';
+import { DateRange } from './useCalendar';
 
 type RecordFormContextState = DateSelectProps & {
   title: string;
@@ -49,9 +50,9 @@ export function RecordFormProvider({
 
   const [images, setImages] = useState<string[]>(defaultProps?.images || []);
 
-  const [date, setDate] = useState({
-    start: new Date(),
-    end: new Date(),
+  const [date, setDate] = useState<DateRange>({
+    start: undefined,
+    end: undefined,
   });
 
   const handleTitleChange = (value: string) => {

--- a/packages/react-native/src/hooks/useTripPlanFormState.tsx
+++ b/packages/react-native/src/hooks/useTripPlanFormState.tsx
@@ -3,6 +3,7 @@ import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 import { CitySelectValue } from '@/components/common/CitySelect';
 import { DateSelectProps } from '@/components/common/DateSelect';
 import { RegionSelectType } from '@/components/tripPlan/RegionSelect';
+import { DateRange } from './useCalendar';
 
 type TripFormContextState = DateSelectProps & {
   region?: RegionSelectType;
@@ -23,14 +24,19 @@ export function TripFormProvider({ children }: TripPlanFormProviderProps) {
   const [region, setRegion] = useState<RegionSelectType>();
   const [selectedCity, setSelectedCity] = useState<CitySelectValue>();
   const [image, setImage] = useState<Asset>();
-  const [date, setDate] = useState({
-    start: new Date(),
-    end: new Date(),
+  const [date, setDate] = useState<DateRange>({
+    start: undefined,
+    end: undefined,
   });
   const [selectionMode, setSelectionMode] = useState<'start' | 'end'>();
 
   const validate = () => {
-    return Boolean(image) && Boolean(region);
+    return (
+      Boolean(image) &&
+      Boolean(region) &&
+      Boolean(date.start) &&
+      Boolean(date.end)
+    );
   };
 
   const changeImage = (imgUrl: Asset) => {

--- a/packages/react-native/src/pages/MyPage/EditProfile.tsx
+++ b/packages/react-native/src/pages/MyPage/EditProfile.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Alert, TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 import { Button, Font, TextField } from 'design-system';
 import useProfileImage from '@/hooks/useProfileImage';

--- a/packages/react-native/src/utils/date.ts
+++ b/packages/react-native/src/utils/date.ts
@@ -1,6 +1,10 @@
 /**
  * Date 객체의 모든 시간을 통일
  * @description 정확한 시간을 비교할 경우 `new Date` 대신 사용
+ *
+ * 인자가 있다면 해당 Date의 UTC 0시 0분 0초 반환
+ *
+ * 인자가 없다면 new Date() 반환
  */
 export const normalizeDate = (date?: Date | string) => {
   const normalizedDate = date ? new Date(date) : new Date();


### PR DESCRIPTION
- 닉네임 프로필의 경우 앞 3글자 까지만 출력되도록 변경
- 날짜 선택 로직 수정
  - 날짜 선택되지 않은 경우 - 선택해주세요라는 문구 출력
  - 첫 클릭 - 시작 날짜로 선택됨
  - 두 번째 클릭 - 끝 날짜로 선택. 단, 시작 날짜보다 이전 날짜를 클릭하는 경우 두 번째 클릭한 날 부터 처음 클릭한 날까지로 일정 설정됨
  - 세 번째 클릭 - 시작 날짜로 선택됨 (이하 동일)
  - 당일치기 - 시작 날짜와 끝 날짜를 같은 날짜로 선택하면 됨
- 날짜 선택 로직 수정에 따른 validation 수정
  - 날짜 선택이 되지 않은 경우 일정 생성 불가
  - 시작 날짜만 선택된 경우 Alert 출력 및 서버로 요청 보내지 않음